### PR TITLE
Fix min Mantine versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     }
   },
   "peerDependencies": {
-    "@mantine/core": "7.1.5",
-    "@mantine/hooks": "7.1.5",
+    "@mantine/core": "^7.1.5",
+    "@mantine/hooks": "^7.1.5",
     "react": ">=16"
   },
   "engines": {
@@ -58,8 +58,8 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.22.5",
-    "@mantine/core": "7.1.5",
-    "@mantine/hooks": "7.1.5",
+    "@mantine/core": "^7.1.5",
+    "@mantine/hooks": "^7.1.5",
     "@size-limit/preset-small-lib": "^8.2.4",
     "@storybook/addon-essentials": "^7.1.0-alpha.33",
     "@storybook/addon-info": "^6.0.0-alpha.2",


### PR DESCRIPTION
Without this change, the only usable Mantine version is 7.1.5.